### PR TITLE
解决actions/upload-pages-artifact版本导致构建失败问题

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -57,7 +57,7 @@ jobs:
           bundle exec htmlproofer _site --disable-external=true --enforce-https=false
 
       - name: Upload site artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: "_site${{ steps.pages.outputs.base_path }}"
 
@@ -71,4 +71,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Fix #6

参考 <https://github.com/cotes2020/chirpy-starter/commit/953dbb08e36148ed4fbb813c9a0ca2d2a0f75a51>
